### PR TITLE
feature: ローカル通知

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,5 +1,7 @@
 PODS:
   - Flutter (1.0.0)
+  - flutter_local_notifications (0.0.1):
+    - Flutter
   - flutter_native_splash (0.0.1):
     - Flutter
   - geolocator_apple (1.2.0):
@@ -9,6 +11,7 @@ PODS:
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
@@ -16,6 +19,8 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   geolocator_apple:
@@ -25,6 +30,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
   flutter_native_splash: edf599c81f74d093a4daf8e17bd7a018854bc778
   geolocator_apple: 6cbaf322953988e009e5ecb481f07efece75c450
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/lib/extension/time_of_day_extension.dart
+++ b/lib/extension/time_of_day_extension.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+extension TimeOfDayExtension on TimeOfDay {
+  tz.TZDateTime toTZDateTime() {
+    final location = tz.getLocation('Asia/Tokyo');
+    final now = tz.TZDateTime.now(location);
+    return tz.TZDateTime(
+      location,
+      now.year,
+      now.month,
+      now.day,
+      hour,
+      minute,
+    );
+  }
+
+  String toJapaneseString() {
+    final hours = hour.toString().padLeft(2, '0');
+    final minutes = minute.toString().padLeft(2, '0');
+    return '$hours時$minutes分';
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:weatherapp_flutter/presentation/pages/home_page.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:timezone/data/latest.dart' as tz;
 
 void main() async {
   await dotenv.load(fileName: '.env');
+  tz.initializeTimeZones();
   runApp(const MyApp());
 }
 
@@ -18,7 +20,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         useMaterial3: true,
       ),
-      home: const HomePage(),
+      home: HomePage(),
     );
   }
 }

--- a/lib/presentation/component/alert/normal_arlert_dialog.dart
+++ b/lib/presentation/component/alert/normal_arlert_dialog.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class NormalAlertDialog extends StatelessWidget {
+  const NormalAlertDialog({
+    super.key,
+    required this.title,
+    required this.message,
+  });
+
+  final String title;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/component/alert/setting_transition_alert_dialog.dart
+++ b/lib/presentation/component/alert/setting_transition_alert_dialog.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+class SettingTransitionAlertDialog extends StatelessWidget {
+  const SettingTransitionAlertDialog({
+    super.key,
+    required this.title,
+    required this.message,
+  });
+  final String title;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text('OK'),
+        ),
+        TextButton(
+          onPressed: () async {
+            Navigator.of(context).pop();
+            await openAppSettings();
+          },
+          child: const Text('設定に移動'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/component/notification_button.dart
+++ b/lib/presentation/component/notification_button.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:weatherapp_flutter/extension/time_of_day_extension.dart';
+import 'package:weatherapp_flutter/presentation/component/alert/normal_arlert_dialog.dart';
+import 'package:weatherapp_flutter/presentation/component/alert/setting_transition_alert_dialog.dart';
+import 'package:weatherapp_flutter/service/notification_service.dart';
+
+class NotificationButton extends StatefulWidget {
+  NotificationButton({
+    super.key,
+  }) : notificationService = NotificationService();
+
+  final NotificationService notificationService;
+
+  @override
+  State<NotificationButton> createState() => _NotificationButtonState();
+}
+
+class _NotificationButtonState extends State<NotificationButton> {
+  bool isSetNotification = false;
+  void _setNotificationStatus() async {
+    final isSet = await widget.notificationService.checkPendingNotifications();
+    setState(() {
+      isSetNotification = isSet;
+    });
+  }
+
+  void resisterNotification() async {
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.now(),
+      builder: (BuildContext ddcontext, Widget? child) {
+        return MediaQuery(
+          data: MediaQuery.of(context).copyWith(alwaysUse24HourFormat: true),
+          child: child!,
+        );
+      },
+    );
+    if (time != null) {
+      final isResister = await widget.notificationService
+          .scheduleDailyNotification(time: time.toTZDateTime());
+      if (!context.mounted) return;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final timeStirng = time.toJapaneseString();
+        final message = isResister ? "毎日$timeStirngに通知します" : "登録失敗しました";
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return NormalAlertDialog(title: "通知の登録", message: message);
+          },
+        );
+      });
+    }
+    _setNotificationStatus();
+  }
+
+  void removeNotification() async {
+    await widget.notificationService.cancelAllNotifications();
+    if (!context.mounted) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      showDialog(
+        context: context,
+        builder: (BuildContext context) {
+          return const NormalAlertDialog(
+              title: "通知の解除", message: "通知の登録を解除しました");
+        },
+      );
+    });
+    _setNotificationStatus();
+  }
+
+  @override
+  void initState() {
+    _setNotificationStatus();
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: isSetNotification
+          ? const Icon(Icons.notifications)
+          : const Icon(Icons.notifications_off_outlined),
+      onPressed: () async {
+        final isActiveNotification =
+            await widget.notificationService.checkNotificationPermissions();
+        if (isActiveNotification) {
+          if (isSetNotification) {
+            removeNotification();
+          } else {
+            resisterNotification();
+          }
+        } else {
+          if (!context.mounted) return;
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            showDialog(
+              context: context,
+              builder: (BuildContext context) {
+                return const SettingTransitionAlertDialog(
+                  title: "通知が許可されていません",
+                  message: "設定から通知を許可してください",
+                );
+              },
+            );
+          });
+        }
+      },
+    );
+  }
+}

--- a/lib/presentation/pages/detail_page.dart
+++ b/lib/presentation/pages/detail_page.dart
@@ -4,6 +4,7 @@ import 'package:weatherapp_flutter/extension/date_time_extension.dart';
 import 'package:weatherapp_flutter/extension/weather_response_extension.dart';
 import 'package:weatherapp_flutter/extension/int_extension.dart';
 import 'package:weatherapp_flutter/model/weather_response_data_model.dart';
+import 'package:weatherapp_flutter/presentation/component/alert/normal_arlert_dialog.dart';
 import 'package:weatherapp_flutter/presentation/component/pop_chart.dart';
 import 'package:weatherapp_flutter/service/weathre_api_service.dart';
 
@@ -54,18 +55,9 @@ class _DetailPageState extends State<DetailPage> {
     showDialog(
       context: context,
       builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text('エラー'),
-          content: Text(message),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop(); // ダイアログを閉じる
-                Navigator.of(context).pop(); // 詳細画面を閉じる
-              },
-              child: const Text('OK'),
-            ),
-          ],
+        return NormalAlertDialog(
+          title: 'エラー',
+          message: message,
         );
       },
     );

--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -1,13 +1,19 @@
 import 'package:flutter/material.dart';
-import 'package:permission_handler/permission_handler.dart';
+import 'package:weatherapp_flutter/presentation/component/alert/setting_transition_alert_dialog.dart';
+import 'package:weatherapp_flutter/presentation/component/notification_button.dart';
 import 'package:weatherapp_flutter/presentation/pages/detail_page.dart';
 import 'package:weatherapp_flutter/presentation/pages/prefecture_select_page.dart';
 import 'package:weatherapp_flutter/service/location_service.dart';
+import 'package:weatherapp_flutter/service/notification_service.dart';
 
 class HomePage extends StatefulWidget {
-  const HomePage({super.key, this.locationService = LocationService.instance});
+  HomePage({
+    super.key,
+    this.locationService = LocationService.instance,
+  }) : notificationService = NotificationService();
 
   final LocationService locationService;
+  final NotificationService notificationService;
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -18,27 +24,18 @@ class _HomePageState extends State<HomePage> {
     showDialog(
       context: context,
       builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text('位置情報が許可されていません'),
-          content: const Text('設定から許可を行ってください。'),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-              child: const Text('OK'),
-            ),
-            TextButton(
-              onPressed: () async {
-                Navigator.of(context).pop();
-                await openAppSettings();
-              },
-              child: const Text('設定に移動'),
-            ),
-          ],
+        return const SettingTransitionAlertDialog(
+          title: '位置情報が許可されていません',
+          message: '設定から許可を行ってください。',
         );
       },
     );
+  }
+
+  @override
+  void initState() {
+    widget.notificationService.initializeNotifications();
+    super.initState();
   }
 
   @override
@@ -49,10 +46,7 @@ class _HomePageState extends State<HomePage> {
           foregroundColor: Colors.white,
           backgroundColor: Colors.orange,
           actions: [
-            IconButton(
-              icon: const Icon(Icons.notifications_none),
-              onPressed: () {},
-            ),
+            NotificationButton(),
           ]),
       body: Center(
         child: Column(

--- a/lib/service/notification_service.dart
+++ b/lib/service/notification_service.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:timezone/timezone.dart' as tz;
+
+class NotificationService {
+  static final NotificationService instance = NotificationService._internal();
+
+  factory NotificationService() {
+    return instance;
+  }
+
+  NotificationService._internal();
+
+  final FlutterLocalNotificationsPlugin _flutterLocalNotificationsPlugin =
+      FlutterLocalNotificationsPlugin();
+
+  void initializeNotifications() async {
+    await _flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>()
+        ?.requestPermissions(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
+    await _flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            MacOSFlutterLocalNotificationsPlugin>()
+        ?.requestPermissions(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
+  }
+
+  Future<bool> checkPendingNotifications() async {
+    final List<PendingNotificationRequest> pendingNotificationRequests =
+        await _flutterLocalNotificationsPlugin.pendingNotificationRequests();
+    if (pendingNotificationRequests.isEmpty) {
+      return false;
+    } else {
+      print(pendingNotificationRequests.first.title);
+      return true;
+    }
+  }
+
+  Future<bool> checkNotificationPermissions() async {
+    final bool? iosPermissionsGranted = await _flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>()
+        ?.requestPermissions(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
+    return iosPermissionsGranted ?? false;
+  }
+
+  Future<bool> scheduleDailyNotification({required tz.TZDateTime time}) async {
+    try {
+      await _flutterLocalNotificationsPlugin.zonedSchedule(
+        0,
+        '今日の天気を確認',
+        '通知をタップして今日の天気を確認',
+        time,
+        const NotificationDetails(
+          iOS: DarwinNotificationDetails(
+            badgeNumber: 1,
+          ),
+        ),
+        uiLocalNotificationDateInterpretation:
+            UILocalNotificationDateInterpretation.absoluteTime,
+        matchDateTimeComponents: DateTimeComponents.time,
+      );
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  Future<void> cancelAllNotifications() async {
+    await _flutterLocalNotificationsPlugin.cancelAll();
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import flutter_local_notifications
 import geolocator_apple
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -782,7 +782,7 @@ packages:
     source: hosted
     version: "0.6.1"
   timezone:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: timezone
       sha256: a6ccda4a69a442098b602c44e61a1e2b4bf6f5516e875bbf0f427d5df14745d5

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -201,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.10"
   dio:
     dependency: "direct main"
     description:
@@ -225,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   file:
     dependency: transitive
     description:
@@ -270,6 +286,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "40e6fbd2da7dcc7ed78432c5cdab1559674b4af035fddbfb2f9a8f9c2112fcef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "17.1.2"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "33f741ef47b5f63cc7f78fe75eeeac7e19f171ff3c3df054d84c1e38bedb6a03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0+1"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "340abf67df238f7f0ef58f4a26d2a83e1ab74c77ab03cd2b2d5018ac64db30b7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.1.0"
   flutter_native_splash:
     dependency: "direct main"
     description:
@@ -741,6 +781,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.1"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: a6ccda4a69a442098b602c44e61a1e2b4bf6f5516e875bbf0f427d5df14745d5
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3"
   timing:
     dependency: transitive
     description:
@@ -813,6 +861,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.5"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: faea9dee56b520b55a566385b84f2e8de55e7496104adada9962e0bd11bcff1d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   json_annotation: ^4.9.0
   permission_handler: ^11.3.1
   sticky_headers: ^0.3.0+2
+  timezone: ^0.9.3
 
 flutter_native_splash:
   image: 'assets/images/splash_logo.png'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_dotenv: ^5.1.0
+  flutter_local_notifications: ^17.1.2
   flutter_native_splash: ^2.4.0
   freezed_annotation: ^2.4.1
   gap: ^3.0.1


### PR DESCRIPTION
## チケットへのリンク
close #12 

## やったこと
【ローカル通知実装】
・NotificationServiceに通知処理をまとめる
通知機能はflutter_local_notificationパッケージを使用
・NotificationButtonとして通知ボタンをコンポーネント化
・Alertを通常アラートと設定遷移アラートでコンポーネント化

## やらないこと
Android端末の通知処理は未実装(2週目は対応します)

## 動作確認
ホーム画面通知ボタンから通知の登録
登録済み→通知の削除
未登録→時間設定のダイアログ表示


https://github.com/oggysy/weatherapp_flutter/assets/93628118/f2b262ce-83d7-4790-bdde-4846bc389828


登録した時間に通知が届くことを確認


<img src="https://github.com/oggysy/weatherapp_flutter/assets/93628118/54b0080c-dc63-4b7c-a3d3-6344b43b69e5" width="40%" />


## その他
時間登録のダイアログはshowTimePickerを使用しました。
Android風のデザインだったのでできればiOSのデザインにしたかったのですが、
今回は機能実装優先でそのまま使いました。